### PR TITLE
Make the -w flag behave as expected

### DIFF
--- a/main.go
+++ b/main.go
@@ -120,11 +120,9 @@ func processFile(filename string, in io.Reader, out io.Writer, stdin bool) error
 
 	if *write {
 		err = ioutil.WriteFile(filename, res, 0644)
-		if err != nil {
-			return err
-		}
+	} else {
+		_, err = out.Write(res)
 	}
 
-	_, err = out.Write(res)
 	return err
 }


### PR DESCRIPTION
The `-w` flag is documented as:

> -w=false: write result to (source) file **instead** of stdout

But in the current implementation, it writes **both** to `file` and `stdout`. If we want it to behave as documented, it should only write to the file when the flag is set.  

This is especially problematic when we try to do some automation around hcl files with hclfmt, stdout logs are pretty annoying  
